### PR TITLE
Expose human-readable site names through provision input and aggregator 

### DIFF
--- a/app/code/aggregator/aggregator.py
+++ b/app/code/aggregator/aggregator.py
@@ -31,10 +31,13 @@ class ScicaAggregator(Aggregator):
         :param fl_ctx: The federated learning context for this run.
         :return: Boolean indicating if the result was successfully accepted.
         """
-        site_name = site_result.get_peer_prop(
+        site_id = site_result.get_peer_prop(
             key=ReservedKey.IDENTITY_NAME, default=None)
-        
-        # Store the result for the site using its identity name as the key
+        computation_parameters = fl_ctx.get_prop(key="COMPUTATION_PARAMETERS", default={})
+        site_id_name_map = computation_parameters.get("site_id_name_map", {})
+        site_name = site_id_name_map.get(site_id, site_id)
+
+        # Store the result for the site using its human-readable name as the key
         self.site_results[site_name] = site_result["result"]
         return True
 

--- a/app/code/executor/executor.py
+++ b/app/code/executor/executor.py
@@ -3,6 +3,9 @@ import os
 import json
 import glob
 import shutil
+import re
+import posixpath
+
 from nvflare.apis.executor import Executor
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.fl_context import FLContext
@@ -20,13 +23,14 @@ OUTPUT_HTML_NAME = "index.html"
 TASK_NAME_PERFORM_COMPUTATION = "perform_scica"
 TASK_NAME_SAVE_AGGREGATE_RESULTS = "save_aggregate_scica_results"
 
+
 class ScicaExecutor(Executor):
     def __init__(self):
         """
         Initialize the SrrExecutor. This constructor sets up the logger.
         """
         logging.info("ScicaExecutor initialized")
-    
+
     def execute(
         self,
         task_name: str,
@@ -36,13 +40,13 @@ class ScicaExecutor(Executor):
     ) -> Shareable:
         """
         Main execution entry point. Routes tasks to specific methods based on the task name.
-        
+
         Parameters:
             task_name: Name of the task to perform.
             shareable: Shareable object containing data for the task.
             fl_ctx: Federated learning context.
             abort_signal: Signal object to handle task abortion.
-            
+
         Returns:
             A Shareable object containing results of the task.
         """
@@ -53,7 +57,7 @@ class ScicaExecutor(Executor):
         else:
             # Raise an error if the task name is unknown
             raise ValueError(f"Unknown task name: {task_name}")
-        
+
     def _do_task_perform_scica(
         self,
         shareable: Shareable,
@@ -77,19 +81,19 @@ class ScicaExecutor(Executor):
         local_parameters = json.load(open(local_parameters_path, "r"))
         computation_parameters = fl_ctx.get_peer_context().get_prop("COMPUTATION_PARAMETERS")
         log_path = os.path.join(get_output_directory_path(fl_ctx), "validation_log.txt")
-        
+
         # Validate the run inputs (covariates, dependent data, and parameters)
         is_valid = validate_run_input(in_files, data_directory, local_parameters, log_path)
-        #is_valid = True
+        # is_valid = True
         if not is_valid:
             # Halt execution if validation fails
             raise ValueError(f"Invalid run input. Check validation log at {log_path}")
-        
+
         # Extract options for cleaner pass to function
         refFiles = local_parameters["refFiles"]
         if not os.path.exists(refFiles) and "neuromark" in refFiles.lower():
-            if '.nii' not in refFiles:
-                refFiles = refFiles + '.nii'
+            if ".nii" not in refFiles:
+                refFiles = refFiles + ".nii"
             refFiles = os.path.join(GIFT_TEMPLATE_PATH, refFiles)
         preproc_type = local_parameters["preproc_type"]
         scaleType = local_parameters["scaleType"]
@@ -98,39 +102,53 @@ class ScicaExecutor(Executor):
         perfType = local_parameters["perfType"]
         dummy_scans = local_parameters["dummy_scans"]
         prefix = local_parameters["prefix"]
-        
+
         # Perform GICA using Nipype functions
-        result = gift_gica(in_files=in_files, 
-                               refFiles=refFiles, 
-                               out_dir=out_dir,
-                               preproc_type=preproc_type, 
-                               scaleType=scaleType,
-                               mask=mask,
-                               TR=TR,
-                               perfType=perfType,
-                               dummy_scans=dummy_scans,
-                               prefix=prefix)
+        result = gift_gica(
+            in_files=in_files,
+            refFiles=refFiles,
+            out_dir=out_dir,
+            preproc_type=preproc_type,
+            scaleType=scaleType,
+            mask=mask,
+            TR=TR,
+            perfType=perfType,
+            dummy_scans=dummy_scans,
+            prefix=prefix,
+        )
 
         # Copy the output result HTML to the base result directory, and name it index.html
-        expected_html_path = os.path.join(out_dir, 
-                                          "{prefix}_gica_results/icatb_gica_html_report.html".format(prefix=prefix))
+        expected_html_path = os.path.join(
+            out_dir, "{prefix}_gica_results/icatb_gica_html_report.html".format(prefix=prefix)
+        )
         final_html_path = os.path.join(out_dir, OUTPUT_HTML_NAME)
         if os.path.exists(expected_html_path):
             shutil.copyfile(expected_html_path, final_html_path)
 
-        # hotfix to replace paths
+        # Hotfix to replace PNG src paths so they resolve correctly from index.html
         with open(final_html_path, "r", encoding="utf-8") as f:
             html = f.read()
-        
-        html = re.sub(r'src="([^"]+\.png)"',
-                      lambda m: f'src="{os.path.join("{prefix}_gica_results".format(prefix=prefix), os.path.basename(m.group(1)))}"',
-                      html)
-        
+
+        # Match: src="x.png", src = "x.png", src='x.PNG', etc. (allow whitespace around '=')
+        src_pattern = re.compile(r'''(\bsrc\s*=\s*)(["'])([^"']+?\.png)\2''', re.IGNORECASE)
+
+        report_dir = f"{prefix}_gica_results"  # folder containing the images next to index.html
+
+        def _rewrite_src(m):
+            src_prefix = m.group(1)  # 'src = ' including original spacing
+            quote = m.group(2)       # ' or "
+            orig = m.group(3)        # original value inside src
+
+            # Use only the filename and point it to the report_dir, with web-safe slashes
+            new_src = posixpath.join(report_dir, posixpath.basename(orig))
+            return f"{src_prefix}{quote}{new_src}{quote}"
+
+        html = src_pattern.sub(_rewrite_src, html)
+
         with open(final_html_path, "w", encoding="utf-8") as f:
             f.write(html)
-    
-        # Prepare the Shareable object to send the result to other components
 
+        # Prepare the Shareable object to send the result to other components
         outgoing_shareable = Shareable()
         # For now, there is nothing to send to the aggregator
         # In the future, we may want to send local files to compute a mean map
@@ -142,7 +160,7 @@ class ScicaExecutor(Executor):
         self,
         shareable: Shareable,
         fl_ctx: FLContext,
-        abort_signal: Signal
+        abort_signal: Signal,
     ) -> Shareable:
         """
         For SCICA this currently does nothing; however, I am leaving this function
@@ -153,8 +171,5 @@ class ScicaExecutor(Executor):
         """
         # Retrieve the global regression result from the Shareable object
         result = shareable.get("result")
-        
-        
-        
-        return Shareable()
 
+        return Shareable()

--- a/app/code/executor/executor.py
+++ b/app/code/executor/executor.py
@@ -117,6 +117,17 @@ class ScicaExecutor(Executor):
         final_html_path = os.path.join(out_dir, OUTPUT_HTML_NAME)
         if os.path.exists(expected_html_path):
             shutil.copyfile(expected_html_path, final_html_path)
+
+        # hotfix to replace paths
+        with open(index_path, "r", encoding="utf-8") as f:
+            html = f.read()
+        
+        html = re.sub(r'src="([^"]+\.png)"',
+                      lambda m: f'src="{os.path.join("{prefix}_gica_results".format(prefix=prefix), os.path.basename(m.group(1)))}"',
+                      html)
+        
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write(html)
     
         # Prepare the Shareable object to send the result to other components
 

--- a/app/code/executor/executor.py
+++ b/app/code/executor/executor.py
@@ -119,14 +119,14 @@ class ScicaExecutor(Executor):
             shutil.copyfile(expected_html_path, final_html_path)
 
         # hotfix to replace paths
-        with open(index_path, "r", encoding="utf-8") as f:
+        with open(final_html_path, "r", encoding="utf-8") as f:
             html = f.read()
         
         html = re.sub(r'src="([^"]+\.png)"',
                       lambda m: f'src="{os.path.join("{prefix}_gica_results".format(prefix=prefix), os.path.basename(m.group(1)))}"',
                       html)
         
-        with open(index_path, "w", encoding="utf-8") as f:
+        with open(final_html_path, "w", encoding="utf-8") as f:
             f.write(html)
     
         # Prepare the Shareable object to send the result to other components

--- a/app/code/executor/executor.py
+++ b/app/code/executor/executor.py
@@ -2,6 +2,7 @@ import logging
 import os
 import json
 import glob
+import shutil
 from nvflare.apis.executor import Executor
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.fl_context import FLContext
@@ -13,6 +14,7 @@ from .validate_run_input import validate_run_input
 
 # Constants
 GIFT_TEMPLATE_PATH = "/computation/gift/GroupICAT/icatb/icatb_templates"
+OUTPUT_HTML_NAME = "index.html"
 
 # Task names
 TASK_NAME_PERFORM_COMPUTATION = "perform_scica"
@@ -108,8 +110,14 @@ class ScicaExecutor(Executor):
                                perfType=perfType,
                                dummy_scans=dummy_scans,
                                prefix=prefix)
-        
 
+        # Copy the output result HTML to the base result directory, and name it index.html
+        expected_html_path = os.path.join(out_dir, 
+                                          "{prefix}_gica_results/icatb_gica_html_report.html".format(prefix=prefix))
+        final_html_path = os.path.join(out_dir, OUTPUT_HTML_NAME)
+        if os.path.exists(expected_html_path):
+            shutil.copyfile(expected_html_path, final_html_path)
+    
         # Prepare the Shareable object to send the result to other components
 
         outgoing_shareable = Shareable()

--- a/display_notes.md
+++ b/display_notes.md
@@ -10,7 +10,7 @@ This computation is designed to run in a federated learning environment; however
 
 ```json
 {
-"refFiles": "Neuromark_fMRI_1.0",
+"refFiles": "Neuromark_fMRI_1.0.nii",
 "preproc_type": 1,
 "scaleType": 0,
 "mask": "default&icv",
@@ -25,7 +25,7 @@ This computation is designed to run in a federated learning environment; however
 
 | Variable Name | Type | Description | Allowed Options | Default | Required |
 | --- | --- | --- | --- | --- | --- |
-| `refFiles` | `string` | The template used as reference for spatially constrained ICA. | Any of the existing templates in GIFT can be specified just by providing the name of the template, with the most commonly used templates being \``` Neuroark_fMRI_1.0` and Neuromark_fMRI_2.0` ``. Additionally a path to a locally provided template can be used, as long as the path is provided in terms of the docker image filesystem | "Neuromark_fMRI_1.0" | ✅ true |
+| `refFiles` | `string` | The template used as reference for spatially constrained ICA. | Any of the existing templates in GIFT can be specified just by providing the name of the template, with the most commonly used templates being `Neuromark_fMRI_1.0.nii` and `Neuromark_fMRI_2.0.nii`. Additionally a path to a locally provided template can be used, as long as the path is provided in terms of the docker image filesystem | "Neuromark_fMRI_1.0.nii" | ✅ true |
 | `preproc_type` | `number` | The type of subject-specific additional preprocessing to do prior to running ICA. | 1 - remove mean per timepoint, 2 - remove mean per voxel, 3 - intensity normalization, 4- variance normalization | 1 | ✅ true |
 | `scaleType` | `number` | The type of scaling to apply to components prior to saving. | 0 - don't scale, 1 - scale to percent signal change, 2 - scale to z-scores | 0 | ✅ true |
 | `mask` | `string` | To have GIFT automatically compute masks, use either the `default` or `default&icv` functions, which compute a mask based on the mean fMRI image (with the ICV image removing eyes); however, these will compute masks locally and may thus differ slightly between sites. A path to a NIFTI file may be provided as long as it is accessible to the computation. The path must be specified in terms of the docker filesystem. | default&ICV, default, or a path to a mask | "default&icv" | ✅ true |

--- a/system/entry_provision.py
+++ b/system/entry_provision.py
@@ -44,8 +44,12 @@ def main():
     path_run = os.path.join('/provisioning')
 
     # Extract arguments from provision input
-    user_ids = provision_input.get('user_ids')
-    computation_parameters = provision_input.get('computation_parameters')
+    users = provision_input.get('users')  # list of {id, name}
+    user_ids = [u['id'] for u in users]
+    site_id_name_map = {u['id']: u['name'] for u in users}
+    computation_parameters_dict = json.loads(provision_input.get('computation_parameters'))
+    computation_parameters_dict['site_id_name_map'] = site_id_name_map
+    computation_parameters = json.dumps(computation_parameters_dict)
     fed_learn_port = provision_input.get('fed_learn_port')
     admin_port = provision_input.get('admin_port')
     host_identifier = provision_input.get('host_identifier')

--- a/system/provision/test_input/provision_input.json
+++ b/system/provision/test_input/provision_input.json
@@ -1,5 +1,9 @@
 {
-    "user_ids": ["user1", "user2", "user3"],
+    "users": [
+        {"id": "user1", "name": "site1"},
+        {"id": "user2", "name": "site2"},
+        {"id": "user3", "name": "site3"}
+    ],
     "computation_parameters": "{\"testKey\":\"testValue\"}",
     "fed_learn_port": 5000,
     "admin_port": 5001,

--- a/test_data_five_subjects/site1/local_parameters.json
+++ b/test_data_five_subjects/site1/local_parameters.json
@@ -1,5 +1,5 @@
 {
-    "refFiles": "Neuromark_fMRI_1.0",
+    "refFiles": "Neuromark_fMRI_1.0.nii",
     "preproc_type": 1,
     "scaleType": 0,
     "mask": "default&icv",


### PR DESCRIPTION
## Summary

- **`system/entry_provision.py`** — Changed to accept a `users` list of `{id, name}` objects instead of a flat `user_ids` list. Builds a `site_id_name_map` from that list and injects it into `computation_parameters` before it is distributed to participants.

- **`app/code/aggregator/aggregator.py`** — Updated `accept_site_result` to look up the site's human-readable name via `site_id_name_map` (from `computation_parameters`) rather than using the raw FLNVFL identity name. Results are now keyed by the meaningful site name (e.g. `"site1"`) instead of an opaque internal ID.

- **`system/provision/test_input/provision_input.json`** — Updated test fixture to use the new `users` schema so local provisioning runs without modification.

- **`test_data_five_subjects/site1/local_parameters.json`** — Fixed `refFiles` value: `Neuromark_fMRI_1.0` → `Neuromark_fMRI_1.0.nii` (missing file extension).

## Why

Downstream consumers of aggregated results (reports, dashboards) expect site names, not internal participant IDs. Injecting the ID→name mapping at provision time keeps the aggregator stateless with respect to naming and avoids a separate lookup step.

## Test plan

- [ ] Run local provisioning with the updated `provision_input.json` and confirm it succeeds without errors
- [ ] Verify `computation_parameters` passed to the executor contains the `site_id_name_map` key with the correct ID→name pairs
- [ ] Run a federated computation end-to-end; confirm aggregated result keys match the human-readable site names (`site1`, `site2`, `site3`) rather than raw IDs
- [ ] Confirm a computation run using `site1` test data finds `Neuromark_fMRI_1.0.nii` without a file-not-found error
- [ ] Regression: confirm that a provision input with a missing `users` key surfaces a clear error rather than a silent failure
