### PR TITLE
Add site ID-to-name mapping and extend heart beat timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ run on individual participants without sharing information between sites.
 #### Data Format Specification
 
 The computation requires at minimum one valid NIFTI (.nii or .nii.gz) file located in the TOP LEVEL of the input folder, as well
-as a parameters.json file with the local parameters for the computation. 
+as a local_parameters.json file with the local parameters for the computation. 
 
 NIFTI files must contain a valid functional MRI image, i.e. which has 4 dimensions (X,Y,Z,Time) and which is 
 readable using the GIFT toolbox. Corrupt or invalid MRI images will cause an error to be thrown in GIFT.
 
 In the future, computations may require BIDS formatting of input data; however, currently that is not required. 
 
-Currently, `parameters.json` is considered a local file, so each site can specify slightly different parameters if they desire; however, in most cases, these will be uniform across sites. The allowed parameters and types are as follows:
+Currently, `local_parameters.json` is considered a local file, so each site can specify slightly different parameters if they desire; however, in most cases, these will be uniform across sites. The allowed parameters and types are as follows:
 
 | Variable Name | Type | Description | Allowed Options | Default |
 | ------ | ------ | ------ | ------ | ------ | 

--- a/app/code/aggregator/aggregator.py
+++ b/app/code/aggregator/aggregator.py
@@ -31,9 +31,12 @@ class ScicaAggregator(Aggregator):
         :param fl_ctx: The federated learning context for this run.
         :return: Boolean indicating if the result was successfully accepted.
         """
-        site_name = site_result.get_peer_prop(
+        site_id = site_result.get_peer_prop(
             key=ReservedKey.IDENTITY_NAME, default=None)
-        
+        computation_parameters = fl_ctx.get_prop(key="COMPUTATION_PARAMETERS", default={})
+        site_id_name_map = computation_parameters.get("site_id_name_map", {})
+        site_name = site_id_name_map.get(site_id, site_id)
+
         # Store the result for the site using its identity name as the key
         self.site_results[site_name] = site_result["result"]
         return True

--- a/app/config/config_fed_server.json
+++ b/app/config/config_fed_server.json
@@ -1,7 +1,7 @@
 {
   "format_version": 2,
   "server": {
-    "heart_beat_timeout": 600
+    "heart_beat_timeout": 86400
   },
   "task_data_filters": [],
   "task_result_filters": [],

--- a/display_notes.md
+++ b/display_notes.md
@@ -36,13 +36,13 @@ This computation is designed to run in a federated learning environment; however
 
 ### Input Description
 
-The computation requires at minimum one valid NIFTI (.nii or .nii.gz) file located in the TOP LEVEL of the input folder, as well as a parameters.json file with the local parameters for the computation.
+The computation requires at minimum one valid NIFTI (.nii or .nii.gz) file located in the TOP LEVEL of the input folder, as well as a local_parameters.json file with the local parameters for the computation.
 
 NIFTI files must contain a valid functional MRI image, i.e. which has 4 dimensions (X,Y,Z,Time) and which is readable using the GIFT toolbox. Corrupt or invalid MRI images will cause an error to be thrown in GIFT.
 
 In the future, computations may require BIDS formatting of input data; however, currently that is not required.
 
-Currently, `parameters.json` is considered a local file, so each site can specify slightly different parameters if they desire; however, in most cases, these will be uniform across sites.
+Currently, `local_parameters.json` is considered a local file, so each site can specify slightly different parameters if they desire; however, in most cases, these will be uniform across sites.
 
 ### Algorithm Description
 

--- a/system/entry_provision.py
+++ b/system/entry_provision.py
@@ -44,8 +44,12 @@ def main():
     path_run = os.path.join('/provisioning')
 
     # Extract arguments from provision input
-    user_ids = provision_input.get('user_ids')
-    computation_parameters = provision_input.get('computation_parameters')
+    users = provision_input.get('users')  # list of {id, name}
+    user_ids = [u['id'] for u in users]
+    site_id_name_map = {u['id']: u['name'] for u in users}
+    computation_parameters_dict = json.loads(provision_input.get('computation_parameters'))
+    computation_parameters_dict['site_id_name_map'] = site_id_name_map
+    computation_parameters = json.dumps(computation_parameters_dict)
     fed_learn_port = provision_input.get('fed_learn_port')
     admin_port = provision_input.get('admin_port')
     host_identifier = provision_input.get('host_identifier')

--- a/system/provision/test_input/provision_input.json
+++ b/system/provision/test_input/provision_input.json
@@ -1,5 +1,9 @@
 {
-    "user_ids": ["user1", "user2", "user3"],
+    "users": [
+        {"id": "66289c79aebab67040a20068", "name": "site1"},
+        {"id": "66289c79aebab67040a20069", "name": "site2"},
+        {"id": "66289c79aebab67040a20070", "name": "site3"}
+    ],
     "computation_parameters": "{\"testKey\":\"testValue\"}",
     "fed_learn_port": 5000,
     "admin_port": 5001,


### PR DESCRIPTION
## Summary

- Provision input schema updated from a flat `user_ids` string array to a `users` list of `{id, name}` objects; a `site_id_name_map` is built at provisioning time and injected into `computation_parameters` so all downstream components can resolve human-readable site names.
- Aggregator now uses `site_id_name_map` to store results under human-readable site names (e.g. `site1`) instead of raw NVFLARE identity IDs (e.g. `66289c79aebab67040a20068`); falls back to raw ID if no mapping exists.
- Server `heart_beat_timeout` raised from 600 s (10 min) to 86400 s (24 h) to prevent sites from being dropped during long-running SCICA/GIFT computations.
- Updated `provision_input.json` test fixture to match the new `users` schema.

## Test plan

- [ ] Run a local end-to-end provisioning using the updated `provision_input.json` and confirm `site_id_name_map` is present inside the generated `computation_parameters`.
- [ ] Confirm the aggregator stores results under the mapped site name (e.g. `site1`) rather than the raw MongoDB-style ID.
- [ ] Verify the fallback: if a site ID has no entry in `site_id_name_map`, the aggregator stores the result under the raw ID without crashing.
- [ ] Confirm `heart_beat_timeout: 86400` appears in the provisioned server config and that a long-running job does not drop client connections prematurely.
- [ ] Ensure any staging/production provision inputs are migrated from the old `user_ids` array format to the new `users` object format before deploying.
